### PR TITLE
feat: test perf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import Minilog from '@cozy/minilog'
 const log = Minilog('ContentScript')
 Minilog.enable()
 
+const getTime = startTime => ((Date.now() - startTime) * 0.001).toFixed(2)
+const formatFromMs = ms => (ms * 0.001).toFixed(2)
+
 const baseUrl = 'http://toscrape.com'
 const defaultSelector = "a[href='http://quotes.toscrape.com']"
 const loginLinkSelector = `[href='/login']`
@@ -93,13 +96,45 @@ class TemplateContentScript extends ContentScript {
   }
 
   async fetch(context) {
+    const startTime = Date.now()
+    this.log('debug', `📥 fetch() - START at 0s`)
+
     log.debug(context, 'fetch context')
     const bookLinkSelector = `[href*='books.toscrape.com']`
+    const timer0 = Date.now()
     await this.goto(baseUrl + '/index.html')
+    this.log(
+      'debug',
+      `📥 fetch() - await this.goto(baseUrl + '/index.html') - START at ${formatFromMs(
+        timer0 - startTime
+      )}s, DONE in ${getTime(timer0)}s`
+    )
+    const timer1 = Date.now()
     await this.waitForElementInWorker(bookLinkSelector)
+    this.log(
+      'debug',
+      `📥 fetch() - await this.waitForElementInWorker(bookLinkSelector) - START at ${formatFromMs(
+        timer1 - startTime
+      )}s, DONE in ${getTime(timer1)}s`
+    )
+    const timer2 = Date.now()
     await this.clickAndWait(bookLinkSelector, '#promotions')
+    this.log(
+      'debug',
+      `📥 fetch() - await this.clickAndWait(bookLinkSelector, '#promotions') - START at ${formatFromMs(
+        timer2 - startTime
+      )}s, DONE in ${getTime(timer2)}s`
+    )
+    const timer3 = Date.now()
     const bills = await this.runInWorker('parseBills')
+    this.log(
+      'debug',
+      `📥 fetch() - await this.runInWorker('parseBills') - START at ${formatFromMs(
+        timer3 - startTime
+      )}s, DONE in ${getTime(timer3)}s`
+    )
 
+    const timer4 = Date.now()
     for (const bill of bills) {
       await this.saveFiles([bill], {
         contentType: 'image/jpeg',
@@ -107,6 +142,12 @@ class TemplateContentScript extends ContentScript {
         context
       })
     }
+    this.log(
+      'debug',
+      `📥 fetch() - await this.saveFiles([bill], {...}) - START at ${formatFromMs(
+        timer4 - startTime
+      )}s, DONE in ${getTime(timer4)}s`
+    )
   }
 
   async getUserDataFromWebsite() {

--- a/src/index.js
+++ b/src/index.js
@@ -7,22 +7,74 @@ const baseUrl = 'http://toscrape.com'
 const defaultSelector = "a[href='http://quotes.toscrape.com']"
 const loginLinkSelector = `[href='/login']`
 const logoutLinkSelector = `[href='/logout']`
-
 class TemplateContentScript extends ContentScript {
   async ensureAuthenticated() {
+    const startTime = Date.now()
+    this.log('debug', '🛡️ ensureAuthenticated START')
     await this.goto(baseUrl)
+    this.log(
+      'debug',
+      `🛡️ ensureAuthenticated goto(baseUrl) DONE in ${(
+        (Date.now() - startTime) *
+        0.001
+      ).toFixed(2)}s`
+    )
     await this.waitForElementInWorker(defaultSelector)
+    this.log(
+      'debug',
+      `🛡️ ensureAuthenticated waitForElementInWorker(defaultSelector) DONE in ${(
+        (Date.now() - startTime) *
+        0.001
+      ).toFixed(2)}s`
+    )
     await this.runInWorker('click', defaultSelector)
+    this.log(
+      'debug',
+      `🛡️ ensureAuthenticated runInWorker(click, defaultSelector) DONE in ${(
+        (Date.now() - startTime) *
+        0.001
+      ).toFixed(2)}s`
+    )
     // wait for both logout or login link to be sure to check authentication when ready
     await Promise.race([
       this.waitForElementInWorker(loginLinkSelector),
       this.waitForElementInWorker(logoutLinkSelector)
     ])
+    this.log(
+      'debug',
+      `🛡️ ensureAuthenticated Promise.race([this.waitForElementInWorker(loginLinkSelector),this.waitForElementInWorker(logoutLinkSelector)]) DONE in ${(
+        (Date.now() - startTime) *
+        0.001
+      ).toFixed(2)}s`
+    )
+
     const authenticated = await this.runInWorker('checkAuthenticated')
+    this.log(
+      'debug',
+      `🛡️ ensureAuthenticated this.runInWorker(checkAuthenticated) DONE in ${(
+        (Date.now() - startTime) *
+        0.001
+      ).toFixed(2)}s`
+    )
     if (!authenticated) {
       this.log('info', 'Not authenticated')
       await this.showLoginFormAndWaitForAuthentication()
+      this.log(
+        'debug',
+        `🛡️ ensureAuthenticated (if not authenticated) this.showLoginFormAndWaitForAuthentication() DONE in ${(
+          (Date.now() - startTime) *
+          0.001
+        ).toFixed(2)}s`
+      )
     }
+
+    this.log(
+      'debug',
+      `🛡️ ensureAuthenticated END in ${(
+        (Date.now() - startTime) *
+        0.001
+      ).toFixed(2)}s`
+    )
     return true
   }
 


### PR DESCRIPTION
The method itself takes 3 seconds approx. The waitForElements methods are clearly what takes the most time here.
```
16:51:26.551 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated START
16:51:26.589 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated goto(baseUrl) DONE in 0.04s
16:51:27.911 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated waitForElementInWorker(defaultSelector) DONE in 1.36s
16:51:27.991 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated runInWorker(click, defaultSelector) DONE in 1.44s
16:51:29.552 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated Promise.race([this.waitForElementInWorker(loginLinkSelector),this.waitForElementInWorker(logoutLinkSelector)]) DONE in 2.99s
16:51:29.626 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated this.runInWorker(checkAuthenticated) DONE in 3.08s
16:51:29.629 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated END in 3.08s
```

```
16:54:04.252 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated START
16:54:04.311 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated goto(baseUrl) DONE in 0.06s
16:54:05.625 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated waitForElementInWorker(defaultSelector) DONE in 1.37s
16:54:05.715 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated runInWorker(click, defaultSelector) DONE in 1.46s
16:54:07.199 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated Promise.race([this.waitForElementInWorker(loginLinkSelector),this.waitForElementInWorker(logoutLinkSelector)]) DONE in 2.94s
16:54:07.276 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated this.runInWorker(checkAuthenticated) DONE in 3.02s
16:54:07.279 minilog.js:17 Konnector template: 🛡️ ensureAuthenticated END in 3.02s
```