### PR TITLE
fix: Remove duplicated got url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,6 @@ class TemplateContentScript extends ContentScript {
   }
 
   async ensureAuthenticated() {
-    await this.goto(baseUrl)
-    await this.waitForElementInWorker(defaultSelector)
-    await this.runInWorker('click', defaultSelector)
-    await this.ensureNotAuthenticated()
     await this.navigateToLoginForm()
     const authenticated = await this.runInWorker('checkAuthenticated')
     if (!authenticated) {


### PR DESCRIPTION
There was duplicated code from goToLoginForm in ensureAuthenticated
There was also a call to ensureNotAuthenticated inside ensureAuthenticated which
was here for debugging purpose
